### PR TITLE
feat(cb2-8131): remove trailer ministry plate

### DIFF
--- a/src/models/SqsPayloadRequest.model.ts
+++ b/src/models/SqsPayloadRequest.model.ts
@@ -12,6 +12,5 @@ export interface SQSRequestBody {
 
 export const enum DocumentName {
   MINISTRY = 'VTG6_VTG7',
-  MINISTRY_TRL = 'VTG6_VTG7_TRL',
   TRL_INTO_SERVICE = 'TrailerIntoService',
 }

--- a/src/services/sqs.service.ts
+++ b/src/services/sqs.service.ts
@@ -48,7 +48,7 @@ export const formatPlatePayload = (techRecord: TechRecord, request: NewPlateRequ
   return {
     vehicle,
     plate,
-    documentName: techRecord.vehicleType === VehicleType.Trailer ? DocumentName.MINISTRY_TRL : DocumentName.MINISTRY,
+    documentName: techRecord.vehicleType === VehicleType.Trailer ? DocumentName.MINISTRY : DocumentName.MINISTRY,
     recipientEmailAddress: request.recipientEmailAddress,
   };
 };

--- a/src/services/sqs.service.ts
+++ b/src/services/sqs.service.ts
@@ -48,7 +48,7 @@ export const formatPlatePayload = (techRecord: TechRecord, request: NewPlateRequ
   return {
     vehicle,
     plate,
-    documentName: techRecord.vehicleType === VehicleType.Trailer ? DocumentName.MINISTRY : DocumentName.MINISTRY,
+    documentName: DocumentName.MINISTRY,
     recipientEmailAddress: request.recipientEmailAddress,
   };
 };

--- a/tests/services/sqs.service.test.ts
+++ b/tests/services/sqs.service.test.ts
@@ -85,7 +85,7 @@ describe('test sqs service', () => {
       const expectedRes = {
         vehicle,
         plate,
-        documentName: DocumentName.MINISTRY_TRL,
+        documentName: DocumentName.MINISTRY,
         recipientEmailAddress: 'customer@example.com'
       };
       expect(res).toEqual(expectedRes);


### PR DESCRIPTION
## Remove the TRL version of the VTG6_VTG7 ministry plate
There are 2 copies of the same form, so any changes or fixes required twice the effort
[CB2-8131](https://dvsa.atlassian.net/browse/CB2-8131)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number